### PR TITLE
Refactor static_argnums to static_argnames

### DIFF
--- a/src/kompressor/image/metrics.py
+++ b/src/kompressor/image/metrics.py
@@ -44,7 +44,7 @@ def imageio_rgb_bpp(batch, *imageio_args, **imageio_kargs):
     return bpp_fn(batch) if (batch.ndim == 3) else np.array(list(map(bpp_fn, batch)))
 
 
-@partial(jax.jit, static_argnums=1)
+@partial(jax.jit, static_argnames=('k',))
 def mean_within_k(batch, k):
     # Compute the percentage of pixels that fall within [-k, +k] of the target
     assert batch.ndim >= 3

--- a/src/kompressor/image/utils.py
+++ b/src/kompressor/image/utils.py
@@ -116,9 +116,8 @@ def highres_from_lowres_and_maps(lowres, maps):
     return highres
 
 
-# TODO make padding default to 0 when JAX merges being able to have static named args in jit functions
 @partial(jax.jit, static_argnames=('padding',))
-def features_from_lowres(lowres, padding):
+def features_from_lowres(lowres, padding=0):
     # Extract the features around each 2x2 neighborhood (assumes the lowres is already padded)
     ph, pw = (lowres.shape[1] - (padding * 2)) - 1, \
              (lowres.shape[2] - (padding * 2)) - 1
@@ -130,7 +129,7 @@ def features_from_lowres(lowres, padding):
 
 
 @partial(jax.jit, static_argnames=('padding',))
-def pad_neighborhood(lowres, padding):
+def pad_neighborhood(lowres, padding=0):
     # Pad only the 2 spatial dimensions
     spatial_padding = ((padding, padding),) * 2
     data_padding    = ((0, 0),) * len(lowres.shape[3:])

--- a/src/kompressor/image/utils.py
+++ b/src/kompressor/image/utils.py
@@ -117,7 +117,7 @@ def highres_from_lowres_and_maps(lowres, maps):
 
 
 # TODO make padding default to 0 when JAX merges being able to have static named args in jit functions
-@partial(jax.jit, static_argnums=1)
+@partial(jax.jit, static_argnames=('padding',))
 def features_from_lowres(lowres, padding):
     # Extract the features around each 2x2 neighborhood (assumes the lowres is already padded)
     ph, pw = (lowres.shape[1] - (padding * 2)) - 1, \
@@ -129,7 +129,7 @@ def features_from_lowres(lowres, padding):
                       for x in range((padding*2)+2)], axis=3)
 
 
-@partial(jax.jit, static_argnums=1)
+@partial(jax.jit, static_argnames=('padding',))
 def pad_neighborhood(lowres, padding):
     # Pad only the 2 spatial dimensions
     spatial_padding = ((padding, padding),) * 2

--- a/src/kompressor/losses.py
+++ b/src/kompressor/losses.py
@@ -41,7 +41,7 @@ def mean_abs_error(pred, gt):
 
 
 @partial(jax.jit, static_argnames=('eps',))
-def mean_charbonnier_error(pred, gt, eps):
+def mean_charbonnier_error(pred, gt, eps=1e-3):
     batch_size = gt.shape[0]
     delta = jnp.sqrt(jnp.square(jnp.float32(gt) - jnp.float32(pred)) + jnp.square(eps))
     return jnp.mean(jnp.reshape(delta, (batch_size, -1)), axis=-1)

--- a/src/kompressor/losses.py
+++ b/src/kompressor/losses.py
@@ -40,7 +40,7 @@ def mean_abs_error(pred, gt):
     return jnp.mean(jnp.reshape(delta, (batch_size, -1)), axis=-1)
 
 
-@partial(jax.jit, static_argnums=2)
+@partial(jax.jit, static_argnames=('eps',))
 def mean_charbonnier_error(pred, gt, eps):
     batch_size = gt.shape[0]
     delta = jnp.sqrt(jnp.square(jnp.float32(gt) - jnp.float32(pred)) + jnp.square(eps))

--- a/src/kompressor/volume/utils.py
+++ b/src/kompressor/volume/utils.py
@@ -196,7 +196,7 @@ def highres_from_lowres_and_maps(lowres, maps):
 
 
 # TODO make padding default to 0 when JAX merges being able to have static named args in jit functions
-@partial(jax.jit, static_argnums=1)
+@partial(jax.jit, static_argnames=('padding',))
 def features_from_lowres(lowres, padding):
     # Extract the features around each 2x2x2 neighborhood (assumes the lowres is already padded)
     pd, ph, pw = (lowres.shape[1] - (padding * 2)) - 1, \
@@ -210,7 +210,7 @@ def features_from_lowres(lowres, padding):
                       for x in range((padding*2)+2)], axis=4)
 
 
-@partial(jax.jit, static_argnums=1)
+@partial(jax.jit, static_argnames=('padding',))
 def pad_neighborhood(lowres, padding):
     # Pad only the 3 spatial dimensions
     spatial_padding = ((padding, padding),) * 3

--- a/src/kompressor/volume/utils.py
+++ b/src/kompressor/volume/utils.py
@@ -195,9 +195,8 @@ def highres_from_lowres_and_maps(lowres, maps):
     return highres
 
 
-# TODO make padding default to 0 when JAX merges being able to have static named args in jit functions
 @partial(jax.jit, static_argnames=('padding',))
-def features_from_lowres(lowres, padding):
+def features_from_lowres(lowres, padding=0):
     # Extract the features around each 2x2x2 neighborhood (assumes the lowres is already padded)
     pd, ph, pw = (lowres.shape[1] - (padding * 2)) - 1, \
                  (lowres.shape[2] - (padding * 2)) - 1, \
@@ -211,7 +210,7 @@ def features_from_lowres(lowres, padding):
 
 
 @partial(jax.jit, static_argnames=('padding',))
-def pad_neighborhood(lowres, padding):
+def pad_neighborhood(lowres, padding=0):
     # Pad only the 3 spatial dimensions
     spatial_padding = ((padding, padding),) * 3
     data_padding    = ((0, 0),) * len(lowres.shape[4:])


### PR DESCRIPTION
Closes #16. Makes functions with static args safer and allows jit'd functions to have default argument values.