### PR TITLE
Refactor map tuples to dicts

### DIFF
--- a/src/kompressor/image/encode_decode.py
+++ b/src/kompressor/image/encode_decode.py
@@ -20,6 +20,10 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+
+import jax
+
+
 # Import kompressor image utilities
 from .utils import \
     lowres_from_highres, maps_from_highres, highres_from_lowres_and_maps, \
@@ -48,7 +52,7 @@ def encode(predictions_fn, encode_fn, highres, padding=0):
     pred_maps = predictions_fn(pad_neighborhood(lowres, padding))
 
     # Compare the predictions to the true values for the pluses, trim the resulting maps if even padding was applied
-    encoded_maps = trim_maps([encode_fn(*maps) for maps in zip(pred_maps, gt_maps)], dims)
+    encoded_maps = trim_maps(jax.tree_multimap(encode_fn, pred_maps, gt_maps), dims)
 
     # Trim even padding off lowres if needed
     lowres = trim(lowres, dims)
@@ -76,7 +80,7 @@ def decode(predictions_fn, decode_fn, lowres, encoded, padding=0):
     pred_maps = predictions_fn(pad_neighborhood(lowres, padding))
 
     # Correct the predictions using the provided encoded maps
-    decoded_maps = [decode_fn(*maps) for maps in zip(pred_maps, encoded_maps)]
+    decoded_maps = jax.tree_multimap(decode_fn, pred_maps, encoded_maps)
 
     # Reconstruct highres image from the corrected true values
     highres = highres_from_lowres_and_maps(lowres, decoded_maps)

--- a/src/kompressor/image/encode_decode_chunk.py
+++ b/src/kompressor/image/encode_decode_chunk.py
@@ -21,6 +21,7 @@
 # SOFTWARE.
 
 from itertools import product
+import jax
 import jax.numpy as jnp
 
 # Import kompressor image utilities
@@ -88,7 +89,7 @@ def process_chunks(predictions_fn, code_fn, lowres, reference_maps, chunk, paddi
     padded_lowres = pad_neighborhood(lowres, padding)
 
     # Pre-allocate full coded maps
-    coded_maps = [jnp.zeros_like(reference_map) for reference_map in reference_maps]
+    coded_maps = jax.tree_map(jnp.zeros_like, reference_maps)
 
     chunks = product(yield_chunks(lh, ch), yield_chunks(lw, cw))
     if progress_fn is not None:
@@ -105,11 +106,18 @@ def process_chunks(predictions_fn, code_fn, lowres, reference_maps, chunk, paddi
         chunk_pred_maps = predictions_fn(chunk_lowres)
 
         # Update each encoded maps with the values for this chunk
-        for idx, (chunk_pred_map, reference_map) in enumerate(zip(chunk_pred_maps, reference_maps)):
+        def chunk_fn(coded_map, chunk_pred_map, reference_map):
+            # Determine the size of the chunk to extract, compensating for padding
             ph, pw = (chunk_pred_map.shape[1] - (py0+py1)), \
                      (chunk_pred_map.shape[2] - (px0+px1))
+
+            # Apply the coding function to the chunk
             chunk_coded_map = code_fn(chunk_pred_map[:, py0:(py0+ph), px0:(px0+pw)],
-                                        reference_map[:, y0:(y0+ph), x0:(x0+pw)])
-            coded_maps[idx] = coded_maps[idx].at[:, y0:(y0+ph), x0:(x0+pw)].set(chunk_coded_map)
+                                       reference_map[:, y0:(y0+ph), x0:(x0+pw)])
+
+            # Write the results into correct location of the full coded map
+            return coded_map.at[:, y0:(y0+ph), x0:(x0+pw)].set(chunk_coded_map)
+
+        coded_maps = jax.tree_multimap(chunk_fn, coded_maps, chunk_pred_maps, reference_maps)
 
     return coded_maps

--- a/tests/image/test_encode_decode.py
+++ b/tests/image/test_encode_decode.py
@@ -69,7 +69,7 @@ class ImageEncodeDecodeTest(unittest.TestCase):
             # Extract the maps from the predictions
             pred_maps = kom.image.maps_from_predictions(predictions)
             # Convert the predictions to dummy logits (one hot encodings)
-            return [jax.nn.softmax(pred_map, axis=-1) for pred_map in pred_maps]
+            return jax.tree_map(partial(jax.nn.softmax, axis=-1), pred_maps)
 
         return predictions_fn
 
@@ -100,7 +100,8 @@ class ImageEncodeDecodeTest(unittest.TestCase):
                 self.assertEqual(ew, 0)
 
                 # Check that the lowres and maps are the correct sizes and dtypes
-                lrmap, udmap, cmap = maps
+                self.assertEqual(len(maps), 3)
+                lrmap, udmap, cmap = maps['lrmap'], maps['udmap'], maps['cmap']
 
                 self.assertEqual(lowres.dtype, highres.dtype)
                 self.assertEqual(lowres.ndim, highres.ndim)
@@ -205,7 +206,8 @@ class ImageEncodeDecodeTest(unittest.TestCase):
                 self.assertEqual(ew, 0)
 
                 # Check that the lowres and maps are the correct sizes and dtypes
-                lrmap, udmap, cmap = maps
+                self.assertEqual(len(maps), 3)
+                lrmap, udmap, cmap = maps['lrmap'], maps['udmap'], maps['cmap']
 
                 self.assertEqual(lowres.dtype, highres.dtype)
                 self.assertEqual(lowres.ndim, highres.ndim)
@@ -308,7 +310,8 @@ class ImageEncodeDecodeTest(unittest.TestCase):
         self.assertEqual(ew, 0)
 
         # Check that the lowres and maps are the correct sizes and dtypes
-        lrmap, udmap, cmap = maps
+        self.assertEqual(len(maps), 3)
+        lrmap, udmap, cmap = maps['lrmap'], maps['udmap'], maps['cmap']
 
         self.assertEqual(lowres.dtype, highres.dtype)
         self.assertEqual(lowres.ndim, highres.ndim)
@@ -379,7 +382,8 @@ class ImageEncodeDecodeTest(unittest.TestCase):
                 # Encode the entire input at once to check for consistency
                 full_lowres, (full_maps, full_dims) = kom.image.encode(predictions_fn, encode_fn, highres,
                                                                        padding=padding)
-                full_lrmap, full_udmap, full_cmap = full_maps
+                self.assertEqual(len(full_maps), 3)
+                full_lrmap, full_udmap, full_cmap = full_maps['lrmap'], full_maps['udmap'], full_maps['cmap']
 
                 # Encode the input in chunks
                 lowres, (maps, dims) = kom.image.encode_chunks(predictions_fn, encode_fn, highres,
@@ -394,7 +398,8 @@ class ImageEncodeDecodeTest(unittest.TestCase):
                 self.assertEqual(ew, full_ew)
 
                 # Check that processing in chunks gives the same results as processing all at once
-                lrmap, udmap, cmap = maps
+                self.assertEqual(len(maps), 3)
+                lrmap, udmap, cmap = maps['lrmap'], maps['udmap'], maps['cmap']
 
                 self.assertEqual(lowres.dtype, full_lowres.dtype)
                 self.assertEqual(lowres.ndim, full_lowres.ndim)
@@ -549,7 +554,8 @@ class ImageEncodeDecodeTest(unittest.TestCase):
                 # Encode the entire input at once to check for consistency
                 full_lowres, (full_maps, full_dims) = kom.image.encode(predictions_fn, encode_fn, highres,
                                                                        padding=padding)
-                full_lrmap, full_udmap, full_cmap = full_maps
+                self.assertEqual(len(full_maps), 3)
+                full_lrmap, full_udmap, full_cmap = full_maps['lrmap'], full_maps['udmap'], full_maps['cmap']
 
                 # Encode the input in chunks
                 lowres, (maps, dims) = kom.image.encode_chunks(predictions_fn, encode_fn, highres,
@@ -564,7 +570,8 @@ class ImageEncodeDecodeTest(unittest.TestCase):
                 self.assertEqual(ew, full_ew)
 
                 # Check that processing in chunks gives the same results as processing all at once
-                lrmap, udmap, cmap = maps
+                self.assertEqual(len(maps), 3)
+                lrmap, udmap, cmap = maps['lrmap'], maps['udmap'], maps['cmap']
 
                 self.assertEqual(lowres.dtype, full_lowres.dtype)
                 self.assertEqual(lowres.ndim, full_lowres.ndim)

--- a/tests/image/test_utils.py
+++ b/tests/image/test_utils.py
@@ -92,7 +92,9 @@ class ImageUtilsTest(unittest.TestCase):
         predictions = kom.image.targets_from_highres(highres)
 
         # Merge duplicate predictions together to get the maps
-        lrmap, udmap, cmap = kom.image.maps_from_predictions(predictions)
+        maps = kom.image.maps_from_predictions(predictions)
+        self.assertEqual(len(maps), 3)
+        lrmap, udmap, cmap = maps['lrmap'], maps['udmap'], maps['cmap']
 
         # Check the merged maps have the correct sizes and dtypes
         self.assertEqual(lrmap.dtype, predictions.dtype)
@@ -132,9 +134,11 @@ class ImageUtilsTest(unittest.TestCase):
         highres = self.dummy_highres()
 
         # Extract the LR, UD, and C maps from the highres
-        lrmap, udmap, cmap = kom.image.maps_from_highres(highres)
+        maps = kom.image.maps_from_highres(highres)
+        self.assertEqual(len(maps), 3)
+        lrmap, udmap, cmap = maps['lrmap'], maps['udmap'], maps['cmap']
 
-        # Check the extracted maps have the correct sizes and dtypes
+            # Check the extracted maps have the correct sizes and dtypes
         self.assertEqual(lrmap.dtype, highres.dtype)
         self.assertEqual(lrmap.ndim, highres.ndim)
         self.assertTrue(np.allclose(lrmap.shape, [

--- a/tests/volume/test_encode_decode.py
+++ b/tests/volume/test_encode_decode.py
@@ -70,7 +70,7 @@ class VolumeEncodeDecodeTest(unittest.TestCase):
             # Extract the maps from the predictions
             pred_maps = kom.volume.maps_from_predictions(predictions)
             # Convert the predictions to dummy logits (one hot encodings)
-            return [jax.nn.softmax(pred_map, axis=-1) for pred_map in pred_maps]
+            return jax.tree_map(partial(jax.nn.softmax, axis=-1), pred_maps)
 
         return predictions_fn
 
@@ -102,7 +102,9 @@ class VolumeEncodeDecodeTest(unittest.TestCase):
                 self.assertEqual(ew, 0)
 
                 # Check that the lowres and maps are the correct sizes and dtypes
-                lrmap, udmap, fbmap, cmap, zmap, ymap, xmap = maps
+                self.assertEqual(len(maps), 7)
+                lrmap, udmap, fbmap, cmap, zmap, ymap, xmap = maps['lrmap'], maps['udmap'], maps['fbmap'], maps['cmap'], \
+                                                              maps['zmap'], maps['ymap'], maps['xmap']
 
                 self.assertEqual(lrmap.dtype, highres.dtype)
                 self.assertEqual(lrmap.ndim, highres.ndim)
@@ -243,7 +245,9 @@ class VolumeEncodeDecodeTest(unittest.TestCase):
                 self.assertEqual(ew, 0)
 
                 # Check that the lowres and maps are the correct sizes and dtypes
-                lrmap, udmap, fbmap, cmap, zmap, ymap, xmap = maps
+                self.assertEqual(len(maps), 7)
+                lrmap, udmap, fbmap, cmap, zmap, ymap, xmap = maps['lrmap'], maps['udmap'], maps['fbmap'], maps['cmap'], \
+                                                              maps['zmap'], maps['ymap'], maps['xmap']
 
                 self.assertEqual(lrmap.dtype, highres.dtype)
                 self.assertEqual(lrmap.ndim, highres.ndim)
@@ -382,7 +386,9 @@ class VolumeEncodeDecodeTest(unittest.TestCase):
         self.assertEqual(ew, 0)
 
         # Check that the lowres and maps are the correct sizes and dtypes
-        lrmap, udmap, fbmap, cmap, zmap, ymap, xmap = maps
+        self.assertEqual(len(maps), 7)
+        lrmap, udmap, fbmap, cmap, zmap, ymap, xmap = maps['lrmap'], maps['udmap'], maps['fbmap'], maps['cmap'], \
+                                                      maps['zmap'], maps['ymap'], maps['xmap']
 
         self.assertEqual(lrmap.dtype, highres.dtype)
         self.assertEqual(lrmap.ndim, highres.ndim)
@@ -487,7 +493,10 @@ class VolumeEncodeDecodeTest(unittest.TestCase):
                 # Encode the entire input at once to check for consistency
                 full_lowres, (full_maps, full_dims) = kom.volume.encode(predictions_fn, encode_fn, highres,
                                                                         padding=padding)
-                full_lrmap, full_udmap, full_fbmap, full_cmap, full_zmap, full_ymap, full_xmap = full_maps
+                self.assertEqual(len(full_maps), 7)
+                full_lrmap, full_udmap, full_fbmap, full_cmap, full_zmap, full_ymap, full_xmap = \
+                    full_maps['lrmap'], full_maps['udmap'], full_maps['fbmap'], full_maps['cmap'], \
+                    full_maps['zmap'],  full_maps['ymap'], full_maps['xmap']
 
                 # Encode the input in chunks
                 lowres, (maps, dims) = kom.volume.encode_chunks(predictions_fn, encode_fn, highres,
@@ -504,7 +513,9 @@ class VolumeEncodeDecodeTest(unittest.TestCase):
                 self.assertEqual(ew, full_ew)
 
                 # Check that processing in chunks gives the same results as processing all at once
-                lrmap, udmap, fbmap, cmap, zmap, ymap, xmap = maps
+                self.assertEqual(len(maps), 7)
+                lrmap, udmap, fbmap, cmap, zmap, ymap, xmap = maps['lrmap'], maps['udmap'], maps['fbmap'], maps['cmap'], \
+                                                              maps['zmap'], maps['ymap'], maps['xmap']
 
                 self.assertEqual(lowres.dtype, full_lowres.dtype)
                 self.assertEqual(lowres.ndim, full_lowres.ndim)
@@ -676,7 +687,10 @@ class VolumeEncodeDecodeTest(unittest.TestCase):
                 # Encode the entire input at once to check for consistency
                 full_lowres, (full_maps, full_dims) = kom.volume.encode(predictions_fn, encode_fn, highres,
                                                                         padding=padding)
-                full_lrmap, full_udmap, full_fbmap, full_cmap, full_zmap, full_ymap, full_xmap = full_maps
+                self.assertEqual(len(full_maps), 7)
+                full_lrmap, full_udmap, full_fbmap, full_cmap, full_zmap, full_ymap, full_xmap = \
+                    full_maps['lrmap'], full_maps['udmap'], full_maps['fbmap'], full_maps['cmap'], \
+                    full_maps['zmap'], full_maps['ymap'], full_maps['xmap']
 
                 # Encode the input in chunks
                 lowres, (maps, dims) = kom.volume.encode_chunks(predictions_fn, encode_fn, highres,
@@ -693,7 +707,9 @@ class VolumeEncodeDecodeTest(unittest.TestCase):
                 self.assertEqual(ew, full_ew)
 
                 # Check that processing in chunks gives the same results as processing all at once
-                lrmap, udmap, fbmap, cmap, zmap, ymap, xmap = maps
+                self.assertEqual(len(maps), 7)
+                lrmap, udmap, fbmap, cmap, zmap, ymap, xmap = maps['lrmap'], maps['udmap'], maps['fbmap'], maps['cmap'], \
+                                                              maps['zmap'], maps['ymap'], maps['xmap']
 
                 self.assertEqual(lowres.dtype, full_lowres.dtype)
                 self.assertEqual(lowres.ndim, full_lowres.ndim)

--- a/tests/volume/test_utils.py
+++ b/tests/volume/test_utils.py
@@ -94,7 +94,10 @@ class VolumeUtilsTest(unittest.TestCase):
         predictions = kom.volume.targets_from_highres(highres)
 
         # Merge duplicate predictions together to get the maps
-        lrmap, udmap, fbmap, cmap, zmap, ymap, xmap = kom.volume.maps_from_predictions(predictions)
+        maps = kom.volume.maps_from_predictions(predictions)
+        self.assertEqual(len(maps), 7)
+        lrmap, udmap, fbmap, cmap, zmap, ymap, xmap = maps['lrmap'], maps['udmap'], maps['fbmap'], maps['cmap'], \
+                                                      maps['zmap'], maps['ymap'], maps['xmap']
 
         # Check the merged maps have the correct sizes and dtypes
         self.assertEqual(lrmap.dtype, predictions.dtype)
@@ -177,7 +180,10 @@ class VolumeUtilsTest(unittest.TestCase):
         highres = self.dummy_highres()
 
         # Extract the LR, UD, FB, C, Z, Y, and X maps from the highres
-        lrmap, udmap, fbmap, cmap, zmap, ymap, xmap = kom.volume.maps_from_highres(highres)
+        maps = kom.volume.maps_from_highres(highres)
+        self.assertEqual(len(maps), 7)
+        lrmap, udmap, fbmap, cmap, zmap, ymap, xmap = maps['lrmap'], maps['udmap'], maps['fbmap'], maps['cmap'], \
+                                                      maps['zmap'], maps['ymap'], maps['xmap']
 
         # Check the extracted maps have the correct sizes and dtypes
         self.assertEqual(lrmap.dtype, highres.dtype)


### PR DESCRIPTION
Closes #14. Functions which currently return an ordered tuple of maps `(lrmap, udmap, cmap, ...)` now return keyed dictionaries `{ 'lrmap': lrmap, 'udmap': udmap, 'cmap': cmap, ...  }` so that order/usage is explicitly enforced.

List comprehensions over the tuples now use `jax.tree_map` and `jax.tree_multimap` to ensure key safety.

@GMW99, this will break the current implementation of the Metrics Callback class which iterates over a zip of the hardcoded map names and the maps tuple. This iteration can be replaced by iterating over `maps.items()` since it is now a dict already.