### PR TITLE
Changed tree_multimap -> tree_map

### DIFF
--- a/src/kompressor/image/encode_decode.py
+++ b/src/kompressor/image/encode_decode.py
@@ -52,7 +52,7 @@ def encode(predictions_fn, encode_fn, highres, padding=0):
     pred_maps = predictions_fn(pad_neighborhood(lowres, padding))
 
     # Compare the predictions to the true values for the pluses, trim the resulting maps if even padding was applied
-    encoded_maps = trim_maps(jax.tree_multimap(encode_fn, pred_maps, gt_maps), dims)
+    encoded_maps = trim_maps(jax.tree_map(encode_fn, pred_maps, gt_maps), dims)
 
     # Trim even padding off lowres if needed
     lowres = trim(lowres, dims)
@@ -80,7 +80,7 @@ def decode(predictions_fn, decode_fn, lowres, encoded, padding=0):
     pred_maps = predictions_fn(pad_neighborhood(lowres, padding))
 
     # Correct the predictions using the provided encoded maps
-    decoded_maps = jax.tree_multimap(decode_fn, pred_maps, encoded_maps)
+    decoded_maps = jax.tree_map(decode_fn, pred_maps, encoded_maps)
 
     # Reconstruct highres image from the corrected true values
     highres = highres_from_lowres_and_maps(lowres, decoded_maps)

--- a/src/kompressor/image/encode_decode_chunk.py
+++ b/src/kompressor/image/encode_decode_chunk.py
@@ -118,6 +118,6 @@ def process_chunks(predictions_fn, code_fn, lowres, reference_maps, chunk, paddi
             # Write the results into correct location of the full coded map
             return coded_map.at[:, y0:(y0+ph), x0:(x0+pw)].set(chunk_coded_map)
 
-        coded_maps = jax.tree_multimap(chunk_fn, coded_maps, chunk_pred_maps, reference_maps)
+        coded_maps = jax.tree_map(chunk_fn, coded_maps, chunk_pred_maps, reference_maps)
 
     return coded_maps

--- a/src/kompressor/volume/encode_decode.py
+++ b/src/kompressor/volume/encode_decode.py
@@ -52,7 +52,7 @@ def encode(predictions_fn, encode_fn, highres, padding=0):
     pred_maps = predictions_fn(pad_neighborhood(lowres, padding))
 
     # Compare the predictions to the true values for the pluses, trim the resulting maps if even padding was applied
-    encoded_maps = trim_maps(jax.tree_multimap(encode_fn, pred_maps, gt_maps), dims)
+    encoded_maps = trim_maps(jax.tree_map(encode_fn, pred_maps, gt_maps), dims)
 
     # Trim even padding off lowres if needed
     lowres = trim(lowres, dims)
@@ -80,7 +80,7 @@ def decode(predictions_fn, decode_fn, lowres, encoded, padding=0):
     pred_maps = predictions_fn(pad_neighborhood(lowres, padding))
 
     # Correct the predictions using the provided encoded maps
-    decoded_maps = jax.tree_multimap(decode_fn, pred_maps, encoded_maps)
+    decoded_maps = jax.tree_map(decode_fn, pred_maps, encoded_maps)
 
     # Reconstruct highres volume from the corrected true values
     highres = highres_from_lowres_and_maps(lowres, decoded_maps)

--- a/src/kompressor/volume/encode_decode_chunk.py
+++ b/src/kompressor/volume/encode_decode_chunk.py
@@ -120,6 +120,6 @@ def process_chunks(predictions_fn, code_fn, lowres, reference_maps, chunk, paddi
             # Write the results into correct location of the full coded map
             return coded_map.at[:, z0:(z0+pd), y0:(y0+ph), x0:(x0+pw)].set(chunk_coded_map)
 
-        coded_maps = jax.tree_multimap(chunk_fn, coded_maps, chunk_pred_maps, reference_maps)
+        coded_maps = jax.tree_map(chunk_fn, coded_maps, chunk_pred_maps, reference_maps)
 
     return coded_maps


### PR DESCRIPTION
14 tests failed as tree_multimap has been deprecated in later versions of Jax. 

Therefore, this was changed to tree_map, which is a drop-in replacement. With this change, all tests now pass.

See [Change Log Jax 0.3.16](https://jax.readthedocs.io/en/latest/changelog.html) 

- jax.tree_util.tree_multimap() has been removed. It has been deprecated since JAX release 0.3.5, and [jax.tree_util.tree_map()](https://jax.readthedocs.io/en/latest/_autosummary/jax.tree_util.tree_map.html#jax.tree_util.tree_map) is a direct replacement.